### PR TITLE
Consider env values when parsing .babrlrc

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const glob = require('glob')
 const pify = require('pify')
 const merge = require('lodash.merge')
+const mergeWith = require('lodash.mergewith')
 const { transformFile } = require('babel-core')
 const readBabelrcUp = require('read-babelrc-up')
 
@@ -13,7 +14,20 @@ const localeMap = arr =>
 
 const getBabelrc = cwd => {
   try {
-    return readBabelrcUp.sync({ cwd }).babel
+    const babelrc = readBabelrcUp.sync({ cwd }).babel
+
+    if (!babelrc.env) {
+      return babelrc
+    }
+
+    const env = process.env.BABEL_ENV || process.env.NODE_ENV || 'development'
+    const concatArray = (obj, src) => {
+      if (Array.isArray(obj)) {
+        return obj.concat(src)
+      }
+    }
+
+    return mergeWith(babelrc, babelrc.env[env], concatArray)
   } catch (err) {
     return { presets: [], plugins: [] }
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-plugin-react-intl": "^2.3.1",
     "glob": "^7.1.1",
     "lodash.merge": "^4.6.0",
+    "lodash.mergewith": "^4.6.0",
     "pify": "^3.0.0",
     "read-babelrc-up": "^0.2.0"
   },

--- a/test/fixtures/.babelrc
+++ b/test/fixtures/.babelrc
@@ -8,9 +8,15 @@
     "react"
   ],
   "plugins": [
-    "transform-class-properties",
-    ["react-intl-auto",
-      {"removePrefix": "test/fixtures/"}
-    ]
-  ]
+    "transform-class-properties"
+  ],
+  "env": {
+    "react-intl": {
+      "plugins":[
+        ["react-intl-auto",
+          {"removePrefix": "test/fixtures/"}
+        ]
+      ]
+    }
+  }
 }

--- a/test/fixtures/.babelrc
+++ b/test/fixtures/.babelrc
@@ -14,7 +14,7 @@
     "react-intl": {
       "plugins":[
         ["react-intl-auto",
-          {"removePrefix": "test/fixtures/"}
+          {"removePrefix": "test.fixtures"}
         ]
       ]
     }

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ const pattern = 'test/fixtures/**/*.js'
 const locales = ['en', 'ja']
 
 test('extract from file', async t => {
+  process.env.BABEL_ENV = 'react-intl'
   const x = await m(locales, pattern, { cwd: './test/fixtures' })
   t.snapshot(x)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,6 +2857,10 @@ lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.mergewith@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
+
 lodash.snakecase@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"


### PR DESCRIPTION
Hello,

The current implementation of `getBabelrc` doesn't consider the [`env` option of .babelrc](https://babeljs.io/docs/usage/babelrc/), which causes an error when a project has extract-react-intl-specific settings under `env` option like this:
https://github.com/nodaguti/extract-react-intl/blob/consider-env/test/fixtures/.babelrc

This PR fixes the above problem by properly handling `env` option using the values of BABEL_ENV, NODE_ENV.

It could be debatable whether this is dealt with by [read-babelrc-up](https://github.com/akameco/read-babelrc-up) or this package, but I believe the former should return the exact content of .babelrc without any modifications or merges, so I've forked this package.

Thanks.