### PR TITLE
Fix bug in path resolution of babel presets and plugins

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 **/test/fixtures/**
+**/test/resolution/**
 flow-typed
 coverage

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/test/fixtures/.*
+.*/test/resolution/.*
 
 [include]
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 // @flow weak
 'use strict'
+const path = require('path')
 const glob = require('glob')
 const pify = require('pify')
 const merge = require('lodash.merge')
@@ -41,7 +42,7 @@ const getBabelrc = cwd => {
   }
 }
 
-const getBabelrcPath = cwd => readBabelrcUp.sync({ cwd }).path
+const getBabelrcDir = cwd => path.dirname(readBabelrcUp.sync({ cwd }).path)
 
 module.exports = (locales, pattern, opts) => {
   if (!Array.isArray(locales)) {
@@ -61,7 +62,7 @@ module.exports = (locales, pattern, opts) => {
   )
 
   const babelrc = getBabelrc(opts.cwd) || {}
-  const babelrcPath = getBabelrcPath(opts.cwd)
+  const babelrcDir = getBabelrcDir(opts.cwd)
 
   const { presets = [], plugins = [] } = babelrc
 
@@ -70,8 +71,8 @@ module.exports = (locales, pattern, opts) => {
 
   const extractFromFile = file => {
     return pify(transformFile)(file, {
-      presets: resolvePresets(presets, babelrcPath),
-      plugins: resolvePlugins(plugins, babelrcPath)
+      presets: resolvePresets(presets, babelrcDir),
+      plugins: resolvePlugins(plugins, babelrcDir)
     }).then(({ metadata: result }) => {
       const localeObj = localeMap(locales)
       for (const { id, defaultMessage } of result['react-intl'].messages) {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`babelrc path resolution 1`] = `
+Object {
+  "en": Object {
+    "test": "test",
+  },
+}
+`;
+
 exports[`extract from file 1`] = `
 Object {
   "en": Object {

--- a/test/resolution/.babelrc
+++ b/test/resolution/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "./.babelrc.js"
+  ]
+}

--- a/test/resolution/.babelrc.js
+++ b/test/resolution/.babelrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ['react-intl']
+}

--- a/test/resolution/messages.js
+++ b/test/resolution/messages.js
@@ -1,0 +1,8 @@
+import { defineMessages } from 'react-intl'
+
+export default defineMessages({
+  test: {
+    id: 'test',
+    defaultMessage: 'test'
+  }
+})

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,13 @@ test('extract from file', async () => {
   expect(x).toMatchSnapshot()
 })
 
+test('babelrc path resolution', async () => {
+  const x = await m(['en'], 'test/resolution/**/*.js', {
+    cwd: './test/resolution'
+  })
+  expect(x).toMatchSnapshot()
+})
+
 test('error', async () => {
   expect.assertions(1)
   await m(locales, 'notfound', { cwd: './test/fixtures' }).catch(err => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**:

These changes fix a bug introduced in #3 , caused by providing incorrect data to babel path resolution utility. 

`getBabelrcPath` function returns path to .babelrc file itself, but `resolve*` babel utilities expect its parent directory in their arguments (so instead of trying to resolve `<root>/.babelrc` it tries to resolve`<root>/.babelrc/.babelrc` and fails with exception).
<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**:

Instead of passing path to babelrc its parent directory will be passed.

Also a simple test with minimal config was added, that was falling without this fix.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] ~~Documentation~~ N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
