### PR TITLE
chore: make babel-core a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,15 @@
     "extract-react-intl"
   ],
   "dependencies": {
-    "babel-core": "^6.26.3",
     "babel-plugin-react-intl": "^2.3.1",
     "glob": "^7.1.1",
     "lodash.merge": "^4.6.1",
     "lodash.mergewith": "^4.6.1",
     "pify": "^3.0.0",
     "read-babelrc-up": "^0.3.0"
+  },
+  "peerDependencies": {
+    "babel-core": "^6 || ^7"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.11.1",

--- a/readme.md
+++ b/readme.md
@@ -9,8 +9,18 @@ This package allows you to extract all messages from a glob. It will return an o
 
 ## Install
 
+This project has a peer dependency on `babel-core`.
+
+To use this with Babel 6, run
+
 ```
-$ yarn add --dev extract-react-intl
+$ yarn add --dev extract-react-intl babel-core
+```
+
+To use this with Babel 7, run
+
+```
+$ yarn add --dev extract-react-intl babel-core@bridge @babel/core
 ```
 
 ## Usage

--- a/yarn.lock
+++ b/yarn.lock
@@ -366,7 +366,7 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-core@^6.26.3:
+babel-core@^6||^7:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:


### PR DESCRIPTION
The user can now choose to use babel 6 or babel 7.

**What**: Babel 7 support is added.

**Why**: Because I need to use this with Babel 7 in a project.

**How**: `babel-core` is moved to peer dependencies and `babel-core@^7` is supported.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests  N/A
* [x] Ready to be merge
* [ ] Added myself to contributors table  N/A

Documentation updates are on the way.
