### PR TITLE
Allow to specify custom module name passed to babel-plugin-react-intl

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,10 +62,13 @@ module.exports = async (locales, pattern, opts) => {
   const babelrc = getBabelrc(opts.cwd) || {}
   const babelrcDir = getBabelrcDir(opts.cwd)
 
+  const {moduleSourceName} = opts;
+  const pluginOptions = moduleSourceName ? {moduleSourceName} : {};
+
   const { presets = [], plugins = [] } = babelrc
 
   // eslint-disable-next-line global-require
-  presets.unshift({ plugins: [require('babel-plugin-react-intl').default] })
+  presets.unshift({ plugins: [[require('babel-plugin-react-intl').default, pluginOptions]] })
 
   const extractFromFile = async file => {
     const { metadata: result } = await pify(transformFile)(file, {

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,12 @@ Type: `string`<br> Default: `en`
 
 Set default locale for your app.
 
+#### moduleSourceName
+
+Type: `string`<br> Example: `./path/to/module` <br> Default: `react-intl`
+
+The ES6 module source name of the React Intl package. Defines from where _defineMessages_, `<FormattedMessage />` and `<FormattedHTMLMessage />` are imported.
+
 ##### cwd
 
 Type: `string`<br> Default: `.`


### PR DESCRIPTION
New option enabled to define module name from where elements defining messages are being imported (instead of default _reacti-intl_). It is passed to **babel-plugin-react-intl**

**Why**:
In case of using custom module based on react-intl, importing _defineMessages_ from it successfully defines messages for an app, but later extraction is not possible without feature mentioned above.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

I was wondering, if adding only _moduleSourceName_ option from all [babel-plugin options](https://github.com/yahoo/babel-plugin-react-intl#options) is OK or not. I think other options are not important (or even do not make sense) in case of **extract-react-intl** context.

What I mean is:
* **messagesDir** - the tool returns object on runtime, do not generates files
* **enforceDescription** - extractor omits descriptions, so I guess it would not be helpful
* **extractSourceLocation** - returned object is flat JSON structure with 'key - message' properties, so additional information would be omitted as well

I wait for other opinions, so if someone consider those needed, I can update the code.