### PR TITLE
Adding support to extract messages from intl.formatMessage calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,14 +62,18 @@ module.exports = async (locales, pattern, opts) => {
   const babelrc = getBabelrc(opts.cwd) || {}
   const babelrcDir = getBabelrcDir(opts.cwd)
 
-  const { moduleSourceName } = opts
+  const { moduleSourceName, extractFromFormatMessageCall } = opts
   const pluginOptions = moduleSourceName ? { moduleSourceName } : {}
-
   const { presets = [], plugins = [] } = babelrc
 
   // eslint-disable-next-line global-require
   presets.unshift({
-    plugins: [[require('babel-plugin-react-intl').default, pluginOptions]]
+    plugins: [
+      [
+        require('babel-plugin-react-intl').default,
+        { ...pluginOptions, extractFromFormatMessageCall }
+      ]
+    ]
   })
 
   const extractFromFile = async file => {

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,20 @@ Type: `string`<br> Example: `./path/to/module` <br> Default: `react-intl`
 
 The ES6 module source name of the React Intl package. Defines from where _defineMessages_, `<FormattedMessage />` and `<FormattedHTMLMessage />` are imported.
 
+#### extractFromFormatMessageCall
+
+Type: `boolean`<br> Example: `--extractFromFormatMessageCall` <br> Default: `react-intl`
+
+If the value is `true`, Extractor will extract the i18n message and ID from `intl.formatMessage` calls as well.
+i:e
+
+```
+intl.formatMessage({
+                id: 'Supported.file.types',
+                defaultMessage: 'Supported file types',
+            })
+```
+
 ##### cwd
 
 Type: `string`<br> Default: `.`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
English/日本語(日本語で入力して大丈夫です。日本語の方が迅速です)
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) / 何が変更されていますか？-->
**What**: Destruct the passed `extractFromFormatMessageCall ` option from options list. If it's available, pass it to babel plugins options. If not, do nothing.


<!-- Why are these changes necessary? / なぜその変更をする必要がありましたか？-->
**Why**: These changes are necessary to enable the IDs & message extraction from `intl.formatMessage` calls , via the `extract-react-intl-messages` tool.


<!-- How were these changes implemented? / これらの変更をどのように実装しましたか？-->
**How**: Simply, Destruct the plugin option, and pass it to underline library call if it's available.


**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments. -->
